### PR TITLE
Add GPU support

### DIFF
--- a/SpaGCN_package/SpaGCN/layers.py
+++ b/SpaGCN_package/SpaGCN/layers.py
@@ -9,13 +9,15 @@ class GraphConvolution(Module):
     Simple GCN layer, similar to https://arxiv.org/abs/1609.02907
     """
 
-    def __init__(self, in_features, out_features, bias=True):
+    def __init__(self, in_features, out_features, bias=True, dtype=torch.float32, device="cpu"):
         super(GraphConvolution, self).__init__()
+        self.device = device
+        self.dtype = dtype
         self.in_features = in_features
         self.out_features = out_features
-        self.weight = Parameter(torch.FloatTensor(in_features, out_features))
+        self.weight = Parameter(torch.rand(in_features, out_features, dtype=self.dtype, device=self.device))
         if bias:
-            self.bias = Parameter(torch.FloatTensor(out_features))
+            self.bias = Parameter(torch.rand(out_features, dtype=self.dtype, device=self.device))
         else:
             self.register_parameter('bias', None)
         self.reset_parameters()

--- a/SpaGCN_package/SpaGCN/util.py
+++ b/SpaGCN_package/SpaGCN/util.py
@@ -342,13 +342,13 @@ def find_meta_gene(input_adata,
     return meta_name, adata.obs["meta"].tolist()
 
 
-def search_res(adata, adj, l, target_num, start=0.4, step=0.1, tol=5e-3, lr=0.05, max_epochs=10, r_seed=100, t_seed=100, n_seed=100, max_run=10):
+def search_res(adata, adj, l, target_num, start=0.4, step=0.1, tol=5e-3, lr=0.05, max_epochs=10, r_seed=100, t_seed=100, n_seed=100, max_run=10, dtype=torch.float32, device="cpu"):
     random.seed(r_seed)
     torch.manual_seed(t_seed)
     np.random.seed(n_seed)
     res=start
     print("Start at res = ", res, "step = ", step)
-    clf=SpaGCN()
+    clf=SpaGCN(dtype=dtype, device=device)
     clf.set_l(l)
     clf.train(adata,adj,init_spa=True,init="louvain",res=res, tol=tol, lr=lr, max_epochs=max_epochs)
     y_pred, _=clf.predict()
@@ -360,7 +360,7 @@ def search_res(adata, adj, l, target_num, start=0.4, step=0.1, tol=5e-3, lr=0.05
         torch.manual_seed(t_seed)
         np.random.seed(n_seed)
         old_sign=1 if (old_num<target_num) else -1
-        clf=SpaGCN()
+        clf=SpaGCN(dtype=dtype, device=device)
         clf.set_l(l)
         clf.train(adata,adj,init_spa=True,init="louvain",res=res+step*old_sign, tol=tol, lr=lr, max_epochs=max_epochs)
         y_pred, _=clf.predict()


### PR DESCRIPTION
To run on GPU, two parameters are added:
1. `dtype`: default is `float32`, which is the same as the original code `FloatTensor`; however, the `dtype` can be set to `bfloat16` or `float16` to reduce the memory and accelerate the training steps.
2. `device`: default is `cpu`, but it can be set to `cuda` (for AMD or NVIDIA), `mps` (for Apple).

The tutorial (data 151673) is tested on Apple M1 chips and Nvidia's A100 device.